### PR TITLE
[API-31] Update GhostScript to 9.52

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Buildpack for Ghostscript
 
-Currently installs Ghostscript 9.19 on Heroku Cedar.
+Currently installs Ghostscript 9.52 on Heroku Cedar.
 
 ## Install
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-echo "-----> Installing Ghostscript 9.19 using build directory $1"
+echo "-----> Installing Ghostscript 9.52 using build directory $1"
 
 BUILD_DIR=$1
-PACKAGE="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs919/ghostscript-9.19-linux-x86_64.tgz"
-BINARY="ghostscript-9.19-linux-x86_64/gs-919-linux_x86_64"
+PACKAGE="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs952/ghostscript-9.52-linux-x86_64.tgz"
+BINARY="ghostscript-9.52-linux-x86_64/gs-952-linux-x86_64"
 LOCATION="$BUILD_DIR/vendor/gs"
 
 cd $BUILD_DIR

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Ghostscript 9.19"
+echo "Ghostscript 9.52"
 exit 0
 


### PR DESCRIPTION
Update GhostScript to 9.52

- [x] tested to upload a PDF that breaks on 9.19 and now works on 9.52